### PR TITLE
More reliable gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var rename = require('gulp-rename');
 
 // Gulp Sass Task
 gulp.task('sass', function() {
-  gulp.src('./sass/{,*/}*.{scss,sass}')
+  gulp.src('./sass/custom/**/*.{scss,sass}')
     .pipe(sourcemaps.init())
     .pipe(sass({
       errLogToConsole: true
@@ -18,5 +18,5 @@ gulp.task('sass', function() {
 // Create Gulp Default Task
 // Having watch within the task ensures that 'sass' has already ran before watching
 gulp.task('default', ['sass'], function () {
-  gulp.watch('./sass/{,*/}*.{scss,sass}', ['sass'])
+  gulp.watch('./sass/**/*.{scss,sass}', ['sass'])
 });


### PR DESCRIPTION
- Tested with node v6.9.5 and npm 3.10.10, the new path is more repsonsive to
  `gulp watch`. Earlier, the `gulp watch` took minutes (or sometime forever)
  to get the watch triggered.