### PR TITLE
Support Drupal 9.

### DIFF
--- a/orange_framework.info.yml
+++ b/orange_framework.info.yml
@@ -4,6 +4,7 @@ description: 'Acro Media Inc. Drupal base theme.'
 package: Core
 version: '1.0.0'
 core: '8.x'
+core_version_requirement: ^8 || ^9
 base theme: false
 
 libraries:

--- a/orange_framework.theme
+++ b/orange_framework.theme
@@ -5,8 +5,7 @@
  * Functions to support theming in the theme.
  */
 
-use Drupal\Core\Template\Attribute;
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_HOOK() for list of available node type templates.
@@ -16,7 +15,7 @@ function orange_framework_preprocess_node_add_list(&$variables) {
     /** @var \Drupal\node\NodeTypeInterface $type */
     foreach ($variables['content'] as $type) {
       $variables['types'][$type->id()]['label'] = $type->label();
-      $variables['types'][$type->id()]['url'] = \Drupal::url('node.add', ['node_type' => $type->id()]);
+      $variables['types'][$type->id()]['url'] = Url::fromRoute('node.add', ['node_type' => $type->id()]);
     }
   }
 }
@@ -32,7 +31,7 @@ function orange_framework_preprocess_block_content_add_list(&$variables) {
     foreach ($variables['content'] as $type) {
       $variables['types'][$type->id()]['label'] = $type->label();
       $options = ['query' => \Drupal::request()->query->all()];
-      $variables['types'][$type->id()]['url'] = \Drupal::url('block_content.add_form', ['block_content_type' => $type->id()], $options);
+      $variables['types'][$type->id()]['url'] = Url::fromRoute('block_content.add_form', ['block_content_type' => $type->id()], $options);
     }
   }
 }


### PR DESCRIPTION
This theme needs minimal changes to support Drupal 9. Here's the report from upgrade_status.

![image](https://user-images.githubusercontent.com/3623162/136079986-12711e6c-8611-46e8-9bf5-00412a401462.png)

This pull request changes the two usages of `Drupal::url` to `Url::fromRoute`, adds `core_version_requirement` to the info file, and removes two unused `use` statements.

I'm not sure how to test this - I'm not sure where to find node_add_list and block_content_add_list - but `Drupal::url` and `url::fromRoute` are essentially identical.